### PR TITLE
Update DNS seed list

### DIFF
--- a/lib/networks.js
+++ b/lib/networks.js
@@ -125,10 +125,11 @@ addNetwork({
   dnsSeeds: [
     'seed.bitcoin.sipa.be',
     'dnsseed.bluematt.me',
-    'dnsseed.bitcoin.dashjr.org',
     'seed.bitcoinstats.com',
-    'seed.bitnodes.io',
-    'bitseed.xf2.org'
+    'seed.bitcoin.jonasschnelli.ch',
+    'seed.btc.petertodd.org',
+    'seed.bitcoin.sprovoost.nl',
+    'dnsseed.emzy.de'
   ]
 });
 


### PR DESCRIPTION
Keep updated relative to the list at:
https://github.com/bitcoin/bitcoin/blob/327d2746fb9240ff0751a7c8f501c9745ba55bba/src/chainparams.cpp#L123-L130

Exclude dnsseed.bitcoin.dashjr.org because this connection is flagged by anti-virus programs as malicious:
https://forums.malwarebytes.com/topic/245141-exodus-wallet-false-positive/?tab=comments#comment-1306435